### PR TITLE
Print out verbose messages for credential chain errors

### DIFF
--- a/local-container-endpoints/handlers/credentials_handler.go
+++ b/local-container-endpoints/handlers/credentials_handler.go
@@ -79,6 +79,7 @@ func NewCredentialService() (*CredentialService, error) {
 	sess, err := session.NewSessionWithOptions(session.Options{
 		Config: aws.Config{
 			EndpointResolver: endpoints.ResolverFunc(customResolverFn),
+			CredentialsChainVerboseErrors: aws.Bool(true),
 		},
 		SharedConfigState: session.SharedConfigEnable,
 	})


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This flag will enable verbose error messages related to credential chain problems.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
