### PR TITLE
Set expiration date on shared temporary credentials.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,3 +37,6 @@ Task Metadata Configuration: while Local Endpoints returns real runtime informat
 * `TASK_ARN` - Set ARN of the mock local 'task' which your containers will appear to be part of in Task Metadata responses. Default: `arn:aws:ecs:us-west-2:111111111111:task/ecs-local-cluster/37e873f6-37b4-42a7-af47-eac7275c6152`.
 * `TASK_DEFINITION_FAMILY` - Set family name for the mock task definition which your containers will appear to be part of in Task Metadata responses. Default: `esc-local-task-definition`.
 * `TASK_DEFINITION_REVISION` - Set the Task Definition revision. Default: `1`.
+
+Credentials Configuration:
+* `SHARED_TOKEN_EXPIRATION` - Set an expiration duration (quantity + unit) for shared credentials when a session token is provided. This provides a hint for clients to refresh their credentials periodically. The default is 750s (12.5 minutes), which results in some clients (notably Boto3) opportunistically refreshing credentials in a background thread.

--- a/integ/README.md
+++ b/integ/README.md
@@ -2,6 +2,10 @@
 
 The Local Credentials Service Integration tests use your local `default` AWS Profile for base credentials.
 
+To test shared temporary credentials (i.e. role-based credentials stored in the
+`~/aws/.credentials` file), ensure the `default` profile contains an
+`aws_session_token` line containing the session token.
+
 Create an IAM role named `ecs-local-endpoints-integ-role`.
 Attach the `AmazonS3ReadOnlyAccess` policy to it. (This includes the required `"s3:List*"` permissions).
 

--- a/local-container-endpoints/config/config.go
+++ b/local-container-endpoints/config/config.go
@@ -30,6 +30,9 @@ const (
 	// Custom endpoint related
 	IAMCustomEndpointVar = "IAM_ENDPOINT"
 	STSCustomEndpointVar = "STS_ENDPOINT"
+
+	// Shared credentials default expiration value when a token is detected.
+	SharedTokenExpirationVar = "SHARED_TOKEN_EXPIRATION"
 )
 
 // Defaults
@@ -43,6 +46,9 @@ const (
 	DefaultTaskARN       = "arn:aws:ecs:us-west-2:111111111111:task/ecs-local-cluster/37e873f6-37b4-42a7-af47-eac7275c6152"
 	DefaultTDFamily      = "esc-local-task-definition"
 	DefaultTDRevision    = "1"
+
+	// Expire shared credentials with a token in 12.5 minutes.
+	DefaultSharedTokenExpiration = 750
 )
 
 // Settings

--- a/local-container-endpoints/handlers/credentials_handler.go
+++ b/local-container-endpoints/handlers/credentials_handler.go
@@ -205,7 +205,7 @@ func (service *CredentialService) getTemporaryCredentials() (*CredentialResponse
 		// timestamp a fixed point in the future.
 		// https://github.com/awslabs/amazon-ecs-local-container-endpoints/issues/26
 		if err != nil && len(response.Token) > 0 {
-			expiration, err = getSharedTokenExpiration();
+			expiration, err = getSharedTokenExpiration()
 		}
 
 		if err == nil {
@@ -256,6 +256,9 @@ func getSharedTokenExpiration() (time.Time, error) {
 		// If they didn't provide a unit, try to parse this as seconds.
 		durationSeconds, err := strconv.ParseInt(durationStr, 0, 64)
 		if err != nil {
+			logrus.Warnf(
+				"Could not parse SHARED_TOKEN_EXPIRATION value, defaulting to %d seconds: %s",
+				config.DefaultSharedTokenExpiration, durationStr)
 			durationSeconds = config.DefaultSharedTokenExpiration
 		}
 
@@ -264,6 +267,9 @@ func getSharedTokenExpiration() (time.Time, error) {
 
 	// Make sure the duration is always in the future.
 	if duration <= 0 {
+		logrus.Warnf(
+			"SHARED_TOKEN_EXPIRATION value must be positive, forcing to %d seconds: %s",
+			config.DefaultSharedTokenExpiration, durationStr)
 		duration = config.DefaultSharedTokenExpiration * time.Second
 	}
 

--- a/local-container-endpoints/handlers/credentials_handler.go
+++ b/local-container-endpoints/handlers/credentials_handler.go
@@ -16,6 +16,7 @@ package handlers
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -195,12 +196,22 @@ func (service *CredentialService) getTemporaryCredentials() (*CredentialResponse
 			SecretAccessKey: credVal.SecretAccessKey,
 			Token:           credVal.SessionToken,
 		}
+
 		expiration, err := service.currentSession.Config.Credentials.ExpiresAt()
-		// It is valid for a credential provider to not return an expiration
-		// TODO: Check if expiration is optional from the POV of the SDKs
+
+		// It is valid for a credential provider to not return an expiration;
+		// however, we need to have an expiration if a token is present to
+		// satsify various client SDKs. In this case, we return an expiration
+		// timestamp a fixed point in the future.
+		// https://github.com/awslabs/amazon-ecs-local-container-endpoints/issues/26
+		if err != nil && len(response.Token) > 0 {
+			expiration, err = getSharedTokenExpiration();
+		}
+
 		if err == nil {
 			response.Expiration = expiration.Format(CredentialExpirationTimeFormat)
 		}
+
 		return &response, nil
 	}
 
@@ -232,4 +243,29 @@ func (service *CredentialService) isCurrentSessionTemporary() bool {
 		}
 	}
 	return false
+}
+
+// Return an expiration date a set point in the future. error is currently
+// always nil (we gracefully fail back to the 12.5 minute default), but we
+// reserve it for future use in case there are valid reasons to error out.
+func getSharedTokenExpiration() (time.Time, error) {
+	durationStr := utils.GetValue(fmt.Sprintf("%ds", config.DefaultSharedTokenExpiration), config.SharedTokenExpirationVar)
+	duration, err := time.ParseDuration(durationStr)
+
+	if err != nil {
+		// If they didn't provide a unit, try to parse this as seconds.
+		durationSeconds, err := strconv.ParseInt(durationStr, 0, 64)
+		if err != nil {
+			durationSeconds = config.DefaultSharedTokenExpiration
+		}
+
+		duration = time.Duration(durationSeconds) * time.Second
+	}
+
+	// Make sure the duration is always in the future.
+	if duration <= 0 {
+		duration = config.DefaultSharedTokenExpiration * time.Second
+	}
+
+	return time.Now().UTC().Add(duration), nil
 }


### PR DESCRIPTION
Fixes https://github.com/awslabs/amazon-ecs-local-container-endpoints/issues/26

*Issue #, if available:* 26

*Description of changes:*
Set expiration date on shared temporary credentials. (See issue for discussion.)

Go isn't one of my everyday languages, so feel free to throw something back if it doesn't look idiomatic. (Lines 207-213 of `credentials_handler.go` are my main concern.)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
