### PR TITLE
Docker build based on alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM amazonlinux:2 as certs
 
-FROM scratch
+# Use alpine which provides 'sh' excutable that is required by aws-sdk-go credential_process
+FROM alpine
 # Add certificates to this scratch image so that we can make calls to the AWS APIs
 COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
'sh' executable is required by aws-sdk-go to [invoke](https://github.com/aws/aws-sdk-go/blob/master/aws/credentials/processcreds/provider.go#L303) credential_process. 
So I'm proposing to use `alpine` as the base image for Docker build, then we can mount any binary/data required to call the credential_process.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
