### PR TITLE
Use amazonlinux as docker build base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-FROM amazonlinux:2 as certs
-
-FROM scratch
-# Add certificates to this scratch image so that we can make calls to the AWS APIs
-COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+# Use amazonlinux as the base image so that:
+# - we have certificates to make calls to the AWS APIs (/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem)
+# - it provides 'sh' excutable that is required by aws-sdk-go credential_process
+FROM amazonlinux:2
 
 COPY ["LICENSE", "NOTICE", "THIRD-PARTY", "/"]
 


### PR DESCRIPTION
*Issue #, if available:* #30 

*Description of changes:* 
Change the base image from `scratch` to `amazonlinux` so that [credential_process](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html) is enabled.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
