### PR TITLE
chore: support ARM architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ out/
 .idea
 .idea/*
 .DS_Store
+
+infra/node_modules
+infra/*.js
+infra/*.d.ts

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 # Use amazonlinux as the base image so that:
 # - we have certificates to make calls to the AWS APIs (/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem)
 # - it provides 'sh' excutable that is required by aws-sdk-go credential_process
+# NOTE: the amazonlinux:2 base image is multi-arch, so docker should be
+# able to detect the correct one to use when the image is run
 FROM amazonlinux:2
 
 COPY ["LICENSE", "NOTICE", "THIRD-PARTY", "/"]
 
-ADD bin/linux-amd64/local-container-endpoints /
+ARG ARCH_DIR
+ADD bin/$ARCH_DIR/local-container-endpoints /
 
 EXPOSE 80
 

--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,8 @@ release-amd:
 		--env ECS_RELEASE=cleanbuild \
 		golang:$(GO_VERSION) make $(AMD_BINARY)
 	docker build -t amazon/amazon-ecs-local-container-endpoints:latest-amd64 .
-	docker tag amazon/amazon-ecs-local-container-endpoints:latest amazon/amazon-ecs-local-container-endpoints:$(TAG)-amd64
-	docker tag amazon/amazon-ecs-local-container-endpoints:latest amazon/amazon-ecs-local-container-endpoints:$(VERSION)-amd64
+	docker tag amazon/amazon-ecs-local-container-endpoints:latest-amd64 amazon/amazon-ecs-local-container-endpoints:$(TAG)-amd64
+	docker tag amazon/amazon-ecs-local-container-endpoints:latest-amd64 amazon/amazon-ecs-local-container-endpoints:$(VERSION)-amd64
 
 .PHONY: release-arm
 release-arm:
@@ -81,8 +81,8 @@ release-arm:
 		--env ECS_RELEASE=cleanbuild \
 		golang:$(GO_VERSION) make $(ARM_BINARY)
 	docker build -t amazon/amazon-ecs-local-container-endpoints:latest-arm64 .
-	docker tag amazon/amazon-ecs-local-container-endpoints:latest amazon/amazon-ecs-local-container-endpoints:$(TAG)-arm64
-	docker tag amazon/amazon-ecs-local-container-endpoints:latest amazon/amazon-ecs-local-container-endpoints:$(VERSION)-arm64
+	docker tag amazon/amazon-ecs-local-container-endpoints:latest-arm64 amazon/amazon-ecs-local-container-endpoints:$(TAG)-arm64
+	docker tag amazon/amazon-ecs-local-container-endpoints:latest-arm64 amazon/amazon-ecs-local-container-endpoints:$(VERSION)-arm64
 
 .PHONY: integ
 integ: release

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,8 @@ TAG := $(VERSION)-agent$(AGENT_VERSION_COMPATIBILITY)-compatible
 local-build: $(LOCAL_BINARY)
 
 # build binaries for each architecture into their own subdirectories
-.PHONY: linux-build
-linux-build: $(AMD_BINARY) $(ARM_BINARY)
+.PHONY: linux-compile
+linux-compile: $(AMD_BINARY) $(ARM_BINARY)
 
 $(LOCAL_BINARY): $(SOURCES)
 	PATH=${PATH} golint ./local-container-endpoints/...
@@ -103,8 +103,8 @@ publish-amd:
 	docker push $(IMAGE_NAME):$(TAG)-amd64
 	docker push $(IMAGE_NAME):$(VERSION)-amd64
 
-.PHONY: publish-arn
-publish-arn:
+.PHONY: publish-arm
+publish-arm:
 	docker push $(IMAGE_NAME):latest-arm64
 	docker push $(IMAGE_NAME):$(TAG)-arm64
 	docker push $(IMAGE_NAME):$(VERSION)-arm64

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ functional-test:
 	go test -mod=vendor -timeout=120s -v -tags functional -cover ./local-container-endpoints/handlers/functional_tests/...
 
 .PHONY: integ
-integ: release
+integ: build-local-image
 	docker build -t amazon-ecs-local-container-endpoints-integ-test:latest -f ./integ/Dockerfile .
 	docker-compose --file ./integ/docker-compose.yml up --abort-on-container-exit
 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -8,8 +8,13 @@ env:
 phases:
   pre_build:
     commands:
-      - echo "Building Image for Amazon ECS Local Container Endpoints..."
+      - echo "Logging into DockerHub..."
       - docker login -u ${USERNAME} --password ${PASSWORD}
   build:
+    # build and tag docker image. This will read ARCH_SUFFIX env var set in the
+    # Codebuild project.
     commands:
-      - make publish
+      - echo Build started on `date`
+      - echo Building Docker image...
+      - make build-image
+      - make publish-dockerhub

--- a/buildspec_verify.yml
+++ b/buildspec_verify.yml
@@ -14,13 +14,9 @@ phases:
       - echo "Logging into DockerHub..."
       - docker login -u ${USERNAME} --password ${PASSWORD}
   build:
-    # build and tag docker image. This will read ARCH_SUFFIX env var set in the
-    # Codebuild project.
     commands:
-      - echo Build started on `date`
-      - echo Building Docker image...
-      - make build-image
-      - make publish-dockerhub
+      - echo "Verifying Docker images..."
+      - make verify
   post_build:
     commands:
       - ok && echo Build completed on `date`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,7 +15,7 @@ For example, on an Ubuntu machine, you can mount your machine's certificates fil
 
 ### Custom IAM and STS Endpoints
 
-Local Endpoionts can be configured to use custom IAM and STS endpoints. Simply define the `IAM_ENDPOINT` and `STS_ENDPOINT` environment variables in the Local Endpoints container.
+Local Endpoints can be configured to use custom IAM and STS endpoints. Simply define the `IAM_ENDPOINT` and `STS_ENDPOINT` environment variables in the Local Endpoints container.
 
 This may be useful in scenarios where your application container is configured to obtain credentials from ECS (see [Vend Credentials to Containers](features.md#vend-credentials-to-containers)), but you do not want to provide Local Endpoints with AWS credentials. Providing an IAM and STS simulator and configuring the Local Endpoints container with custom IAM and STS endpoints enables testing without an AWS account.
 

--- a/docs/setup-networking.md
+++ b/docs/setup-networking.md
@@ -37,5 +37,5 @@ docker run -d -p 51679:51679 \
 -v $HOME/.aws/:/home/.aws/ \
 -e "ECS_LOCAL_METADATA_PORT=51679" \
 --name ecs-local-endpoints \
-amazon/amazon-ecs-local-container-endpoints:latest
+amazon/amazon-ecs-local-container-endpoints:latest-amd64
 ```

--- a/docs/setup-networking.md
+++ b/docs/setup-networking.md
@@ -1,9 +1,10 @@
 ## Setting Up Networking
 
-ECS Local Container Endpoints supports 3 endpoints:
+ECS Local Container Endpoints supports 4 endpoints:
 * The [ECS Task IAM Roles endpoint](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html)
 * The [Task Metadata V2 Endpoint](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v2.html)
 * The [Task Metadata V3 Endpoint](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v3.html)
+* The [Task Metadata V4 Endpoint](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4.html)
 
 The Task Metadata V2 and Credentials endpoints require the Local Endpoints container to be able to receive requests made to the special IP Address, `169.254.170.2`.
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,31 @@
+# Continuous delivery pipelines
+
+This package uses the [AWS Cloud Development Kit (AWS)](https://github.com/awslabs/aws-cdk) to model AWS CodePipeline pipelines and to provision them with AWS CloudFormation.
+
+* pipeline.ts: Builds and publishes the base Docker image for the backend API service
+
+This creates as CodePipeline pipeline which consists of a souce stage that usees a GitHub webhook and a build stage that uses AWS CodeBuild to build and publish Docker images to DockerHub.
+
+## GitHub Access Token
+The official pipeilne uses a team account (ecs-local-container-endpoints+release@amazon.com).
+
+Create a GitHub [personal access token](https://github.com/settings/tokens) with access to your fork of the repo, including "admin:repo_hook" and "repo" permissions.  Then store the token in Secrets Manager:
+
+```
+aws secretsmanager create-secret --region us-west-2 --name EcsDevXGitHubToken --secret-string <my-github-personal-access-token>
+```
+
+## Deploy
+
+To deploy this pipeline, install the AWS CDK CLI: `npm i -g aws-cdk`
+
+Install and build everything: `npm install && npm run build`
+
+Then deploy the pipeline stacks:
+
+```
+cdk deploy --app 'node pipeline.js'
+
+```
+
+See the pipelines in the CodePipeline console.

--- a/infra/README.md
+++ b/infra/README.md
@@ -2,9 +2,11 @@
 
 This package uses the [AWS Cloud Development Kit (AWS)](https://github.com/awslabs/aws-cdk) to model AWS CodePipeline pipelines and to provision them with AWS CloudFormation.
 
-* pipeline.ts: Builds and publishes the base Docker image for the backend API service
+* pipeline.ts: Builds and publishes the base Docker image for amazon/amazon-ecs-local-container-endpoints.
 
-This creates as CodePipeline pipeline which consists of a souce stage that usees a GitHub webhook and a build stage that uses AWS CodeBuild to build and publish Docker images to DockerHub.
+This creates as CodePipeline pipeline which consists of a souce stage that uses
+a GitHub webhook, and build stages that uses AWS CodeBuild to build, publish
+and verify Docker images for both amd64 and arm64 architectures to DockerHub.
 
 ## GitHub Access Token
 The official pipeilne uses a team account (ecs-local-container-endpoints+release@amazon.com).

--- a/infra/buildspec.yml
+++ b/infra/buildspec.yml
@@ -1,0 +1,15 @@
+version: 0.2
+
+env:
+  secrets-manager:
+    USERNAME: "com.amazonaws.ec2.madison.dockerhub.amazon-ecs-local-container-endpoints.credentials:username"
+    PASSWORD: "com.amazonaws.ec2.madison.dockerhub.amazon-ecs-local-container-endpoints.credentials:password"
+
+phases:
+  pre_build:
+    commands:
+      - echo "Building Image for Amazon ECS Local Container Endpoints..."
+      - docker login -u ${USERNAME} --password ${PASSWORD}
+  build:
+    commands:
+      - make publish

--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -1,0 +1,2181 @@
+{
+  "name": "local-container-endpoints-pipeline",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "local-container-endpoints-pipeline",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/aws-codebuild": "*",
+        "@aws-cdk/aws-codepipeline": "*",
+        "@aws-cdk/aws-codepipeline-actions": "*",
+        "@aws-cdk/aws-codestarnotifications": "*",
+        "@aws-cdk/aws-ec2": "*",
+        "@aws-cdk/aws-ecr": "*",
+        "@aws-cdk/aws-ecs": "*",
+        "@aws-cdk/aws-iam": "*",
+        "@aws-cdk/core": "*"
+      },
+      "devDependencies": {
+        "@types/node": "^12.15.0",
+        "typescript": "~3.8.3"
+      }
+    },
+    "node_modules/@aws-cdk/assets": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-1.94.1.tgz",
+      "integrity": "sha512-PymrsEZB1b06l7fXzrtvy86EE/im06liL5Jeg2GOQ4r8Fk9hVS0XMlagJCWZRZxePTvG3q/dGQ2e5yJxnyDIZQ==",
+      "dependencies": {
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/cx-api": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-apigateway": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigateway/-/aws-apigateway-1.94.1.tgz",
+      "integrity": "sha512-b9SW6mlVaUl3E28hCYkgWn+PAmZ83Rq8z/S2pT/HMmRQ5sC8NYQUSTkO4ArExKhnfLG72QbRKmqgtjsqGhsnVg==",
+      "dependencies": {
+        "@aws-cdk/aws-certificatemanager": "1.94.1",
+        "@aws-cdk/aws-cloudwatch": "1.94.1",
+        "@aws-cdk/aws-cognito": "1.94.1",
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-elasticloadbalancingv2": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-lambda": "1.94.1",
+        "@aws-cdk/aws-logs": "1.94.1",
+        "@aws-cdk/aws-s3": "1.94.1",
+        "@aws-cdk/aws-s3-assets": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/cx-api": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-apigatewayv2": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2/-/aws-apigatewayv2-1.94.1.tgz",
+      "integrity": "sha512-cfRHFumN59B2dwwjQSEbAuIHuAmEUPcX9cKtWPDoP5bbsu1y7L3/ym6F8OiMqL5SqyYc0+EnrOcjf+R/ZkzZaA==",
+      "dependencies": {
+        "@aws-cdk/aws-certificatemanager": "1.94.1",
+        "@aws-cdk/aws-cloudwatch": "1.94.1",
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-applicationautoscaling": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.94.1.tgz",
+      "integrity": "sha512-LgnLHpRKZxq5xryDvOzDnc22oR+gx2lYEkhGE2f6gtatG1oSrKpiOWRvQMOEFSz7FpAwvaEfN9KzHUkvP21brg==",
+      "dependencies": {
+        "@aws-cdk/aws-autoscaling-common": "1.94.1",
+        "@aws-cdk/aws-cloudwatch": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-autoscaling": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling/-/aws-autoscaling-1.94.1.tgz",
+      "integrity": "sha512-HC2edeBJ59tgAIUBERY9K1KClByMFPiMbo4nrLunWHiX4VnLwRELy9D1q8WU2nhs/cbJ+RBL/FN4TlSt/R7Sjg==",
+      "dependencies": {
+        "@aws-cdk/aws-autoscaling-common": "1.94.1",
+        "@aws-cdk/aws-cloudwatch": "1.94.1",
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-elasticloadbalancing": "1.94.1",
+        "@aws-cdk/aws-elasticloadbalancingv2": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-sns": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-autoscaling-common": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.94.1.tgz",
+      "integrity": "sha512-XI6dIR3IobS50SMOlbNj5PlGgL1/FlOrls8RyfSXmPfK0sa3S+C2I6yfAEDYwFsBJkgoJstmHZGG+8m7KeW3dQ==",
+      "dependencies": {
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-autoscaling-hooktargets": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-hooktargets/-/aws-autoscaling-hooktargets-1.94.1.tgz",
+      "integrity": "sha512-Qhui+1yTpIB3JVaub/dmLB3CqaUBD5vv1c46MO76djhiu8VP2c5O0eV9WM+f1BSg7btDtXhB+ZZqk3aU+tUAig==",
+      "dependencies": {
+        "@aws-cdk/aws-autoscaling": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-kms": "1.94.1",
+        "@aws-cdk/aws-lambda": "1.94.1",
+        "@aws-cdk/aws-sns": "1.94.1",
+        "@aws-cdk/aws-sns-subscriptions": "1.94.1",
+        "@aws-cdk/aws-sqs": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-batch": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-batch/-/aws-batch-1.94.1.tgz",
+      "integrity": "sha512-DYAnEHKYG6FqpIMe9xLzHDkrf+Y/+Y18yGu2qCmMNxWEbcUUm7hE3nbSBD6Oc4nGQWtac6IASMi6duwlr1L8Aw==",
+      "peer": true,
+      "dependencies": {
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-ecr": "1.94.1",
+        "@aws-cdk/aws-ecs": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-secretsmanager": "1.94.1",
+        "@aws-cdk/aws-ssm": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-ecr": "1.94.1",
+        "@aws-cdk/aws-ecs": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-secretsmanager": "1.94.1",
+        "@aws-cdk/aws-ssm": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-certificatemanager": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.94.1.tgz",
+      "integrity": "sha512-AfEGF8ongl/UizPYs/ETKorzbwTCzxlrGLaO81VZucz5ykEegHNrRVzVrMPhquHDQdH5TeKsKvBhi97ZzE3X8Q==",
+      "dependencies": {
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-lambda": "1.94.1",
+        "@aws-cdk/aws-route53": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-cloudformation": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.94.1.tgz",
+      "integrity": "sha512-+HTjG6ud/NeB+t6sArPzg6nXJNIDszqR8mMyKWiHvZ8ZqhFEZdmUviRzvcrI2IAJp/JgKD3RTZC8DmxqtBIJzw==",
+      "dependencies": {
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-lambda": "1.94.1",
+        "@aws-cdk/aws-s3": "1.94.1",
+        "@aws-cdk/aws-sns": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/cx-api": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-cloudfront": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudfront/-/aws-cloudfront-1.94.1.tgz",
+      "integrity": "sha512-JzLXx+kOZtvK3IvdwPBUPPQPwyK1EluQ2ZjQpOtcZL7sVB8nHWRAQlpSW2drc0b6ijE6YP1fZWrc12b93ohDbA==",
+      "dependencies": {
+        "@aws-cdk/aws-certificatemanager": "1.94.1",
+        "@aws-cdk/aws-cloudwatch": "1.94.1",
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-kms": "1.94.1",
+        "@aws-cdk/aws-lambda": "1.94.1",
+        "@aws-cdk/aws-s3": "1.94.1",
+        "@aws-cdk/aws-ssm": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-cloudwatch": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.94.1.tgz",
+      "integrity": "sha512-11b7N9xKm2m83BUCh6Cm0yyBIDmEgvwC7r3grNeYsj5vEDjcA56d4RlwGwkV7Grl5FpcuCvr5adtcIqYQa9Gng==",
+      "dependencies": {
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-codebuild": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codebuild/-/aws-codebuild-1.94.1.tgz",
+      "integrity": "sha512-lVTheXuBFZBBPFkShcupqgXq7kziSoWt8D/UCXpGfnxh1+FAi+u868wNXp3Db/EsTzTI5LW9p1yzngq3gKOdFA==",
+      "dependencies": {
+        "@aws-cdk/aws-cloudwatch": "1.94.1",
+        "@aws-cdk/aws-codecommit": "1.94.1",
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-ecr": "1.94.1",
+        "@aws-cdk/aws-ecr-assets": "1.94.1",
+        "@aws-cdk/aws-events": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-kms": "1.94.1",
+        "@aws-cdk/aws-logs": "1.94.1",
+        "@aws-cdk/aws-s3": "1.94.1",
+        "@aws-cdk/aws-s3-assets": "1.94.1",
+        "@aws-cdk/aws-secretsmanager": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/region-info": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-codecommit": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codecommit/-/aws-codecommit-1.94.1.tgz",
+      "integrity": "sha512-grf+7GMsEtX++sBMG1ttYjCuHFghHLaV4bagZpvBjtAHxOPlO7rMe+WEc4ZU8lykt+tm/EfmmSYp1oKbOpezEQ==",
+      "dependencies": {
+        "@aws-cdk/aws-events": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-codedeploy": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codedeploy/-/aws-codedeploy-1.94.1.tgz",
+      "integrity": "sha512-55rW+g8vTdqarepbxVLEG9K1g4MKHpFEO3kIo6Z0rFgbS0xk244kNae2m9Bg6qXarcy6Fsj5wCL1cILk9rwvKg==",
+      "peer": true,
+      "dependencies": {
+        "@aws-cdk/aws-autoscaling": "1.94.1",
+        "@aws-cdk/aws-cloudwatch": "1.94.1",
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-elasticloadbalancing": "1.94.1",
+        "@aws-cdk/aws-elasticloadbalancingv2": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-lambda": "1.94.1",
+        "@aws-cdk/aws-s3": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/custom-resources": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-autoscaling": "1.94.1",
+        "@aws-cdk/aws-cloudwatch": "1.94.1",
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-elasticloadbalancing": "1.94.1",
+        "@aws-cdk/aws-elasticloadbalancingv2": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-lambda": "1.94.1",
+        "@aws-cdk/aws-s3": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/custom-resources": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-codeguruprofiler": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.94.1.tgz",
+      "integrity": "sha512-8QBvoScA85NUlNmG2Bo13lOLWDcLI+DvPkb7qcS+oKHNboWwu5iuVUApCXQg/cE2XyMLRyX/QZdSzVkUDrEpNA==",
+      "dependencies": {
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-codepipeline": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codepipeline/-/aws-codepipeline-1.94.1.tgz",
+      "integrity": "sha512-1QSguGHyjOsUMsuE+c6YA3RvEDim6RP8fHNNafqqBB8A4bBDVLRJ8PSEaxagJGQ4ataOU1LZD2StaccSVvrLrg==",
+      "dependencies": {
+        "@aws-cdk/aws-events": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-kms": "1.94.1",
+        "@aws-cdk/aws-s3": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-codepipeline-actions": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codepipeline-actions/-/aws-codepipeline-actions-1.94.1.tgz",
+      "integrity": "sha512-GvyrKCoc8yEbyhacE+5Y5Ovk118xh7BeuWKn928DfNMHSmrN1NSuzPyhl51drdXVMR8bjT8wJtHpkXgtd33TeA==",
+      "bundleDependencies": [
+        "case"
+      ],
+      "dependencies": {
+        "@aws-cdk/aws-cloudformation": "1.94.1",
+        "@aws-cdk/aws-codebuild": "1.94.1",
+        "@aws-cdk/aws-codecommit": "1.94.1",
+        "@aws-cdk/aws-codedeploy": "1.94.1",
+        "@aws-cdk/aws-codepipeline": "1.94.1",
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-ecr": "1.94.1",
+        "@aws-cdk/aws-ecs": "1.94.1",
+        "@aws-cdk/aws-events": "1.94.1",
+        "@aws-cdk/aws-events-targets": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-lambda": "1.94.1",
+        "@aws-cdk/aws-s3": "1.94.1",
+        "@aws-cdk/aws-servicecatalog": "1.94.1",
+        "@aws-cdk/aws-sns": "1.94.1",
+        "@aws-cdk/aws-sns-subscriptions": "1.94.1",
+        "@aws-cdk/aws-stepfunctions": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "case": "1.6.3",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-cloudformation": "1.94.1",
+        "@aws-cdk/aws-codebuild": "1.94.1",
+        "@aws-cdk/aws-codecommit": "1.94.1",
+        "@aws-cdk/aws-codedeploy": "1.94.1",
+        "@aws-cdk/aws-codepipeline": "1.94.1",
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-ecr": "1.94.1",
+        "@aws-cdk/aws-ecs": "1.94.1",
+        "@aws-cdk/aws-events": "1.94.1",
+        "@aws-cdk/aws-events-targets": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-lambda": "1.94.1",
+        "@aws-cdk/aws-s3": "1.94.1",
+        "@aws-cdk/aws-servicecatalog": "1.94.1",
+        "@aws-cdk/aws-sns": "1.94.1",
+        "@aws-cdk/aws-sns-subscriptions": "1.94.1",
+        "@aws-cdk/aws-stepfunctions": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-codepipeline-actions/node_modules/case": {
+      "version": "1.6.3",
+      "inBundle": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-codestarnotifications": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codestarnotifications/-/aws-codestarnotifications-1.94.1.tgz",
+      "integrity": "sha512-sTgKgs/JOUABdXEnyZ+sNaQ2U5uk8mjZ+CWljQjRRqqUTPMDKoNpyrGxZb4SweO+7LDqrZM/CEA5P6UlqA7ApQ==",
+      "dependencies": {
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-cognito": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cognito/-/aws-cognito-1.94.1.tgz",
+      "integrity": "sha512-9BxCqIFc0wMCOdf9gzHxr9Xr1u7rVOh2x8kNYR0jli1xkjd89/hCyTqLPFcdfaFquW9bT3BTvR2mX+BGn5LejA==",
+      "bundleDependencies": [
+        "punycode"
+      ],
+      "dependencies": {
+        "@aws-cdk/aws-certificatemanager": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-lambda": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/custom-resources": "1.94.1",
+        "constructs": "^3.2.0",
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-cognito/node_modules/punycode": {
+      "version": "2.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@aws-cdk/aws-ec2": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-1.94.1.tgz",
+      "integrity": "sha512-Jh/W9xmkmmX2wUyKYQikFKLFjHYqSaLPV9s03fpAGOMGwrxgvlHJ5m2fGAKwwygAgxnFdkP1QjSgRy5mgoTL2g==",
+      "dependencies": {
+        "@aws-cdk/aws-cloudwatch": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-kms": "1.94.1",
+        "@aws-cdk/aws-logs": "1.94.1",
+        "@aws-cdk/aws-s3": "1.94.1",
+        "@aws-cdk/aws-s3-assets": "1.94.1",
+        "@aws-cdk/aws-ssm": "1.94.1",
+        "@aws-cdk/cloud-assembly-schema": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/cx-api": "1.94.1",
+        "@aws-cdk/region-info": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-ecr": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr/-/aws-ecr-1.94.1.tgz",
+      "integrity": "sha512-jq3CAkzntedLRQMJyCbPo0UtfDJtaToAxxP0l/ChaQifzw8grMYl/GVoLcGTqNMLivWWLF6jO5EBlapi7qEs5w==",
+      "dependencies": {
+        "@aws-cdk/aws-events": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-ecr-assets": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.94.1.tgz",
+      "integrity": "sha512-QtbHcrs69V9jiIXvPXFQAfhNEzgXGoAtdI7SdkW8OT6UCYpgz0aaPD6bo89Q7cIY46cEq0NoSsNLAZRYxgyk/Q==",
+      "bundleDependencies": [
+        "balanced-match",
+        "brace-expansion",
+        "concat-map",
+        "minimatch"
+      ],
+      "dependencies": {
+        "@aws-cdk/assets": "1.94.1",
+        "@aws-cdk/aws-ecr": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-s3": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/cx-api": "1.94.1",
+        "constructs": "^3.2.0",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-ecr-assets/node_modules/balanced-match": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws-cdk/aws-ecr-assets/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@aws-cdk/aws-ecr-assets/node_modules/concat-map": {
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws-cdk/aws-ecr-assets/node_modules/minimatch": {
+      "version": "3.0.4",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/aws-ecs": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecs/-/aws-ecs-1.94.1.tgz",
+      "integrity": "sha512-w1KZ3BVNOrysp9Jjcg2ddf1iEg6hSd8qZ8/GrZsS+qAZXTY0uNWr1ZbcZGNn3xWdtRZNkdbfEjTEuw/V2iUFmg==",
+      "dependencies": {
+        "@aws-cdk/aws-applicationautoscaling": "1.94.1",
+        "@aws-cdk/aws-autoscaling": "1.94.1",
+        "@aws-cdk/aws-autoscaling-hooktargets": "1.94.1",
+        "@aws-cdk/aws-certificatemanager": "1.94.1",
+        "@aws-cdk/aws-cloudwatch": "1.94.1",
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-ecr": "1.94.1",
+        "@aws-cdk/aws-ecr-assets": "1.94.1",
+        "@aws-cdk/aws-elasticloadbalancing": "1.94.1",
+        "@aws-cdk/aws-elasticloadbalancingv2": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-kms": "1.94.1",
+        "@aws-cdk/aws-lambda": "1.94.1",
+        "@aws-cdk/aws-logs": "1.94.1",
+        "@aws-cdk/aws-route53": "1.94.1",
+        "@aws-cdk/aws-route53-targets": "1.94.1",
+        "@aws-cdk/aws-s3": "1.94.1",
+        "@aws-cdk/aws-s3-assets": "1.94.1",
+        "@aws-cdk/aws-secretsmanager": "1.94.1",
+        "@aws-cdk/aws-servicediscovery": "1.94.1",
+        "@aws-cdk/aws-sns": "1.94.1",
+        "@aws-cdk/aws-sqs": "1.94.1",
+        "@aws-cdk/aws-ssm": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/cx-api": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-efs": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-efs/-/aws-efs-1.94.1.tgz",
+      "integrity": "sha512-rU9LaUe824+RStI+aoV0uJULC0pLtTDyq7INrv2lP/2IvtP2xC5GxkY5UexP4jKa2ONcnytIRi8tJMUf7inM3w==",
+      "dependencies": {
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-kms": "1.94.1",
+        "@aws-cdk/cloud-assembly-schema": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/cx-api": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-elasticloadbalancing": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-1.94.1.tgz",
+      "integrity": "sha512-J8eNu0GY8lRFg6s5GwPCl2xdVMg/VaqCSnwKjzar8opXDpKPFcmDOzXtEuhsR63vw7k3oG8WBoOUlUkkHkUemg==",
+      "dependencies": {
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-elasticloadbalancingv2": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-1.94.1.tgz",
+      "integrity": "sha512-0HUk6QIUTTCE3iWapzOFRwih2nW+LSL6oZDzyawP6ekoPw/rCfcR4AdRcU/ByirRTHWG3WRzoBeOb4jltQYenQ==",
+      "dependencies": {
+        "@aws-cdk/aws-certificatemanager": "1.94.1",
+        "@aws-cdk/aws-cloudwatch": "1.94.1",
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-lambda": "1.94.1",
+        "@aws-cdk/aws-s3": "1.94.1",
+        "@aws-cdk/cloud-assembly-schema": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/cx-api": "1.94.1",
+        "@aws-cdk/region-info": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-events": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-1.94.1.tgz",
+      "integrity": "sha512-5S8PnBM3ApQ+ghW6C+Jpm543zN4lFESA6SViWHCrFXEcmVWnM4QeDl5QbU4Gu68pLqmr3dAbf22Yf9zUfA8aYQ==",
+      "dependencies": {
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-events-targets": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events-targets/-/aws-events-targets-1.94.1.tgz",
+      "integrity": "sha512-hp2+XVnkTHpbGVd/hzIC9Jf048Ct1NQNqFal1MfnvfS8HgHRCBsul0egmMcxQ13Zw9drzit3TJdBuTOZ4GmVJA==",
+      "peer": true,
+      "dependencies": {
+        "@aws-cdk/aws-batch": "1.94.1",
+        "@aws-cdk/aws-codebuild": "1.94.1",
+        "@aws-cdk/aws-codepipeline": "1.94.1",
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-ecs": "1.94.1",
+        "@aws-cdk/aws-events": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-kinesis": "1.94.1",
+        "@aws-cdk/aws-kinesisfirehose": "1.94.1",
+        "@aws-cdk/aws-lambda": "1.94.1",
+        "@aws-cdk/aws-logs": "1.94.1",
+        "@aws-cdk/aws-sns": "1.94.1",
+        "@aws-cdk/aws-sns-subscriptions": "1.94.1",
+        "@aws-cdk/aws-sqs": "1.94.1",
+        "@aws-cdk/aws-stepfunctions": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/custom-resources": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-batch": "1.94.1",
+        "@aws-cdk/aws-codebuild": "1.94.1",
+        "@aws-cdk/aws-codepipeline": "1.94.1",
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-ecs": "1.94.1",
+        "@aws-cdk/aws-events": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-kinesis": "1.94.1",
+        "@aws-cdk/aws-kinesisfirehose": "1.94.1",
+        "@aws-cdk/aws-lambda": "1.94.1",
+        "@aws-cdk/aws-logs": "1.94.1",
+        "@aws-cdk/aws-sns": "1.94.1",
+        "@aws-cdk/aws-sns-subscriptions": "1.94.1",
+        "@aws-cdk/aws-sqs": "1.94.1",
+        "@aws-cdk/aws-stepfunctions": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/custom-resources": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-globalaccelerator": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-globalaccelerator/-/aws-globalaccelerator-1.94.1.tgz",
+      "integrity": "sha512-40uZK7nMb7EAGZVmij9sAi1Ql3M9wuFwfDubYIOCFPunxLF5kDdsbj4T33L08ys8ODOTq+qQwetp7cDxnPmvpg==",
+      "dependencies": {
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/custom-resources": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-iam": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-1.94.1.tgz",
+      "integrity": "sha512-LzdIZzRntlbidGjTG4FXENoMw2QYJQNU6gC9vERHV59NQceOIzzOPlhu+JtbjHpJaY1JN81yQQ01/q317zsIBQ==",
+      "dependencies": {
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/region-info": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-kinesis": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kinesis/-/aws-kinesis-1.94.1.tgz",
+      "integrity": "sha512-UO9RUVGExxuHfwnRqAiYgLNbGNe4zoxFXT3C3a3bAqecrTL1PxYunEDDgrby+hwu9YwdvKCw6wszFTzCthMF4A==",
+      "peer": true,
+      "dependencies": {
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-kms": "1.94.1",
+        "@aws-cdk/aws-logs": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-kms": "1.94.1",
+        "@aws-cdk/aws-logs": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-kinesisfirehose": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kinesisfirehose/-/aws-kinesisfirehose-1.94.1.tgz",
+      "integrity": "sha512-IoJ6dxjJixMrnQyee1yiZ05J0TjoHnHvBNdMIawkxKGdl/uUTN8y0lvW1zV+8FqFbjuEi3Tp1FYiCk6KjHkWEA==",
+      "peer": true,
+      "dependencies": {
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-kms": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-1.94.1.tgz",
+      "integrity": "sha512-2XUMUKC/wiEsOEC32SvhNl19BpdJgoVCXbF6BCXFPcz9uEYb4DsDIOpdw/9N2sFSKImgpmNfnlNE0qomIqb9ow==",
+      "dependencies": {
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/cx-api": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-lambda": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-1.94.1.tgz",
+      "integrity": "sha512-hRnjWqVJb4OJfX+OL8elpJjuouB/3ryaXFK+b/UJZzT5P+0aY7g6aDC426NsfZpy8JRz5Xcclh4c8nvkIL43EQ==",
+      "dependencies": {
+        "@aws-cdk/aws-applicationautoscaling": "1.94.1",
+        "@aws-cdk/aws-cloudwatch": "1.94.1",
+        "@aws-cdk/aws-codeguruprofiler": "1.94.1",
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-ecr": "1.94.1",
+        "@aws-cdk/aws-ecr-assets": "1.94.1",
+        "@aws-cdk/aws-efs": "1.94.1",
+        "@aws-cdk/aws-events": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-kms": "1.94.1",
+        "@aws-cdk/aws-logs": "1.94.1",
+        "@aws-cdk/aws-s3": "1.94.1",
+        "@aws-cdk/aws-s3-assets": "1.94.1",
+        "@aws-cdk/aws-signer": "1.94.1",
+        "@aws-cdk/aws-sqs": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/cx-api": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-logs": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-1.94.1.tgz",
+      "integrity": "sha512-6RC2fJzfVRAoOmZrThiU1wuciJShinM93gjpABBpG7PNhXTXKkgfRmlxLDq0sl3HnxGoL1hZg5EWWcgYgcK4Aw==",
+      "dependencies": {
+        "@aws-cdk/aws-cloudwatch": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-kms": "1.94.1",
+        "@aws-cdk/aws-s3-assets": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-route53": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53/-/aws-route53-1.94.1.tgz",
+      "integrity": "sha512-ywX65oc5FPqGCGizkPrDfaM0XF90N/+GGnmcKGWV9GAilBmOwSI7IhiSZYI5Js0jQj8GBBuzP9J6hkPTWhsaYw==",
+      "dependencies": {
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-logs": "1.94.1",
+        "@aws-cdk/cloud-assembly-schema": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/custom-resources": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-route53-targets": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53-targets/-/aws-route53-targets-1.94.1.tgz",
+      "integrity": "sha512-wkG4OhWitukrVoZ7LEjV3nPYxhBGkvvlzFBPA9HLJibtaoJqvQF0BQZh17sb/vepDJIS54FFwMa/g04On0GJnA==",
+      "dependencies": {
+        "@aws-cdk/aws-apigateway": "1.94.1",
+        "@aws-cdk/aws-apigatewayv2": "1.94.1",
+        "@aws-cdk/aws-cloudfront": "1.94.1",
+        "@aws-cdk/aws-cognito": "1.94.1",
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-elasticloadbalancing": "1.94.1",
+        "@aws-cdk/aws-elasticloadbalancingv2": "1.94.1",
+        "@aws-cdk/aws-globalaccelerator": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-route53": "1.94.1",
+        "@aws-cdk/aws-s3": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/region-info": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-s3": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-1.94.1.tgz",
+      "integrity": "sha512-9Ggl7Zgp9ZXSri8yB/RUDgK3YxM4oa/8I1STGc9hGaN6lniZhplJab9dsccVGy458HjnKPeP86OeWcbWgH7PWQ==",
+      "dependencies": {
+        "@aws-cdk/aws-events": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-kms": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/cx-api": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-s3-assets": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.94.1.tgz",
+      "integrity": "sha512-MkhxS5dQzVMIzx0NBRhgfPtYDcOfBicYpXhvWIT1SkMcwqgR6pCfBm42dWLRChQs1Wdhd+zmv9Nfrpi9PcdMGw==",
+      "dependencies": {
+        "@aws-cdk/assets": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-kms": "1.94.1",
+        "@aws-cdk/aws-s3": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/cx-api": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-sam": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sam/-/aws-sam-1.94.1.tgz",
+      "integrity": "sha512-5TrY/ywbIOJhdWBayclXZU56XfTPXX9fbFD30USKkmpu+jdmMHZO/iuABlUz+ZIWdl9lLsF2HgA0TjfXX1G/Ow==",
+      "dependencies": {
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-secretsmanager": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-secretsmanager/-/aws-secretsmanager-1.94.1.tgz",
+      "integrity": "sha512-rhuE7+7WEXp7s1Kli/A+Qh7LJXZybUIow3pbxU3TNHWJD1I3PHAQM5SN4Onp2XkejutnGE6m/nhB7/TzuG+xcg==",
+      "dependencies": {
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-kms": "1.94.1",
+        "@aws-cdk/aws-lambda": "1.94.1",
+        "@aws-cdk/aws-sam": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/cx-api": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-servicecatalog": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-servicecatalog/-/aws-servicecatalog-1.94.1.tgz",
+      "integrity": "sha512-PAqbLACMdAZH8c4NzrLMyMKzOlwX6SakZJEfMVv66uEV9pSAKL7W2KCSzHETn+Ojt9fRKsnwCo2Phaxi5jDHPA==",
+      "peer": true,
+      "dependencies": {
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-servicediscovery": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-servicediscovery/-/aws-servicediscovery-1.94.1.tgz",
+      "integrity": "sha512-k82MKxSrFkcEuTY2f90B7LUeiyOdwz7f7W6BFtMmRDUu5zyeZl8QcpSLp+7RXrPXCJtQJrqss8bMuV139wWyrg==",
+      "dependencies": {
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-elasticloadbalancingv2": "1.94.1",
+        "@aws-cdk/aws-route53": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-signer": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-signer/-/aws-signer-1.94.1.tgz",
+      "integrity": "sha512-oktp02YKDIiTJiBraN6XXuRN5JOx00qvJKK+SPSzXgPE5kTn9kCQOjS3QyasSam+Vx9la8GCx4ir9TEC/6NoEA==",
+      "dependencies": {
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-sns": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns/-/aws-sns-1.94.1.tgz",
+      "integrity": "sha512-tGbgOS3rwtigdOTZMMiRHiUqIe4Uklji1OcBtcHAdBoblj/LQArrpZPQuoNGaiZiT0vtAqco25990agKCLibFA==",
+      "dependencies": {
+        "@aws-cdk/aws-cloudwatch": "1.94.1",
+        "@aws-cdk/aws-events": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-kms": "1.94.1",
+        "@aws-cdk/aws-sqs": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-sns-subscriptions": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns-subscriptions/-/aws-sns-subscriptions-1.94.1.tgz",
+      "integrity": "sha512-HksIHzwDhgnlE+6lwj+3WETqoJuz4zhzceggoFlbd9cDgIq/0T7LUm7M3E9Rhf2VbKdMmJnkTiH8gyKt34XD/A==",
+      "dependencies": {
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-lambda": "1.94.1",
+        "@aws-cdk/aws-sns": "1.94.1",
+        "@aws-cdk/aws-sqs": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-sqs": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sqs/-/aws-sqs-1.94.1.tgz",
+      "integrity": "sha512-579LZ7002KfJB3qPsnVBSR+EMV4Jbj11mk1LNepsTnZgdjs1d2dKZve4ZVY1TOW3jW7cqwM/ZccJ5X9bzwoUlA==",
+      "dependencies": {
+        "@aws-cdk/aws-cloudwatch": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-kms": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-ssm": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ssm/-/aws-ssm-1.94.1.tgz",
+      "integrity": "sha512-bsZ5nHnRiNwVVKpEEHZYx/BgH+rd+NzRRaM2yd43LvAsuBuT6ZzN4CcnjHMMKtoucNkBI0GRcaHc/MyXRP3bRw==",
+      "dependencies": {
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-kms": "1.94.1",
+        "@aws-cdk/cloud-assembly-schema": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-stepfunctions": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-stepfunctions/-/aws-stepfunctions-1.94.1.tgz",
+      "integrity": "sha512-jLa14T+AD4AmjU7zCRWrWFPIedgDBdxjImkbJBYnMV2s/cmQC/k/cGFD/u2+fMUCe8pZTsRhCps8o5MUXw2/cw==",
+      "peer": true,
+      "dependencies": {
+        "@aws-cdk/aws-cloudwatch": "1.94.1",
+        "@aws-cdk/aws-events": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-logs": "1.94.1",
+        "@aws-cdk/aws-s3": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-cloudwatch": "1.94.1",
+        "@aws-cdk/aws-events": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-logs": "1.94.1",
+        "@aws-cdk/aws-s3": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.94.1.tgz",
+      "integrity": "sha512-Cp1O8JQBcJl6uqdRSIagqvCrRdnvUu18G7T4daMbIP9zLPimXHlIwEOxg3um/ivV/bCO4JdJwWnyi15MjbqF+Q==",
+      "bundleDependencies": [
+        "jsonschema",
+        "lru-cache",
+        "semver",
+        "yallist"
+      ],
+      "dependencies": {
+        "jsonschema": "^1.4.0",
+        "semver": "^7.3.4"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.4.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.3.4",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/yallist": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@aws-cdk/core": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/core/-/core-1.94.1.tgz",
+      "integrity": "sha512-wMbiPFnAEGNd3CInGiS1qr3/8w356g3NleiKCD1NI2RdIdXUD9Dba5DhtuGJYXGLsysrvwRiEqux2LrH/2A2JQ==",
+      "bundleDependencies": [
+        "@balena/dockerignore",
+        "at-least-node",
+        "balanced-match",
+        "brace-expansion",
+        "concat-map",
+        "fs-extra",
+        "graceful-fs",
+        "ignore",
+        "jsonfile",
+        "minimatch",
+        "universalify"
+      ],
+      "dependencies": {
+        "@aws-cdk/cloud-assembly-schema": "1.94.1",
+        "@aws-cdk/cx-api": "1.94.1",
+        "@aws-cdk/region-info": "1.94.1",
+        "@balena/dockerignore": "^1.0.2",
+        "constructs": "^3.2.0",
+        "fs-extra": "^9.1.0",
+        "ignore": "^5.1.8",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/core/node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@aws-cdk/core/node_modules/at-least-node": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/@aws-cdk/core/node_modules/balanced-match": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws-cdk/core/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@aws-cdk/core/node_modules/concat-map": {
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws-cdk/core/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws-cdk/core/node_modules/graceful-fs": {
+      "version": "4.2.6",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@aws-cdk/core/node_modules/ignore": {
+      "version": "5.1.8",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@aws-cdk/core/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@aws-cdk/core/node_modules/minimatch": {
+      "version": "3.0.4",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/core/node_modules/universalify": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-cdk/custom-resources": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/custom-resources/-/custom-resources-1.94.1.tgz",
+      "integrity": "sha512-ArosnFXRExSoBsIJ4wixrEnfynZ6OIDV9w+C8zjc6E0/fsuYlDgttyDdF2IPPFRXW6TE8o/V+Dr8M4pHKhv6pQ==",
+      "dependencies": {
+        "@aws-cdk/aws-cloudformation": "1.94.1",
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-lambda": "1.94.1",
+        "@aws-cdk/aws-logs": "1.94.1",
+        "@aws-cdk/aws-sns": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/cx-api": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.94.1.tgz",
+      "integrity": "sha512-ME6A7dsHbyZv859jhmUhGv9D9soShS0Jafruad87iphBuujfaxruG3aHc8UGIDV6opaW8euVLrEVNZ3H0cMM/w==",
+      "bundleDependencies": [
+        "lru-cache",
+        "semver",
+        "yallist"
+      ],
+      "dependencies": {
+        "@aws-cdk/cloud-assembly-schema": "1.94.1",
+        "semver": "^7.3.4"
+      },
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@aws-cdk/cx-api/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws-cdk/cx-api/node_modules/semver": {
+      "version": "7.3.4",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws-cdk/cx-api/node_modules/yallist": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@aws-cdk/region-info": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.94.1.tgz",
+      "integrity": "sha512-FcflZlta6SqlebWT0Dhwo3FLTblbsUSh7T1J5uRG0BINw2EwunaQr/isl23M1qQoaASsnY1TIbMt+WYYsWbuNQ==",
+      "engines": {
+        "node": ">= 10.13.0 <13 || >=13.7.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "12.20.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.6.tgz",
+      "integrity": "sha512-sRVq8d+ApGslmkE9e3i+D3gFGk7aZHAT+G4cIpIEdLJYPsWiSPwcAnJEjddLQQDqV3Ra2jOclX/Sv6YrvGYiWA==",
+      "dev": true
+    },
+    "node_modules/constructs": {
+      "version": "3.3.71",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.71.tgz",
+      "integrity": "sha512-3KFtTsA7OV27m/+pJhN4iJkKzHbPIPvyvEX5BQ/JCAWjfCHOQEVpIgxHLpT4i8L1OFta+pJrzcEVAHo6UitwqA==",
+      "engines": {
+        "node": ">= 10.17.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    }
+  },
+  "dependencies": {
+    "@aws-cdk/assets": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-1.94.1.tgz",
+      "integrity": "sha512-PymrsEZB1b06l7fXzrtvy86EE/im06liL5Jeg2GOQ4r8Fk9hVS0XMlagJCWZRZxePTvG3q/dGQ2e5yJxnyDIZQ==",
+      "requires": {
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/cx-api": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-apigateway": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigateway/-/aws-apigateway-1.94.1.tgz",
+      "integrity": "sha512-b9SW6mlVaUl3E28hCYkgWn+PAmZ83Rq8z/S2pT/HMmRQ5sC8NYQUSTkO4ArExKhnfLG72QbRKmqgtjsqGhsnVg==",
+      "requires": {
+        "@aws-cdk/aws-certificatemanager": "1.94.1",
+        "@aws-cdk/aws-cloudwatch": "1.94.1",
+        "@aws-cdk/aws-cognito": "1.94.1",
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-elasticloadbalancingv2": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-lambda": "1.94.1",
+        "@aws-cdk/aws-logs": "1.94.1",
+        "@aws-cdk/aws-s3": "1.94.1",
+        "@aws-cdk/aws-s3-assets": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/cx-api": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-apigatewayv2": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2/-/aws-apigatewayv2-1.94.1.tgz",
+      "integrity": "sha512-cfRHFumN59B2dwwjQSEbAuIHuAmEUPcX9cKtWPDoP5bbsu1y7L3/ym6F8OiMqL5SqyYc0+EnrOcjf+R/ZkzZaA==",
+      "requires": {
+        "@aws-cdk/aws-certificatemanager": "1.94.1",
+        "@aws-cdk/aws-cloudwatch": "1.94.1",
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-applicationautoscaling": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.94.1.tgz",
+      "integrity": "sha512-LgnLHpRKZxq5xryDvOzDnc22oR+gx2lYEkhGE2f6gtatG1oSrKpiOWRvQMOEFSz7FpAwvaEfN9KzHUkvP21brg==",
+      "requires": {
+        "@aws-cdk/aws-autoscaling-common": "1.94.1",
+        "@aws-cdk/aws-cloudwatch": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-autoscaling": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling/-/aws-autoscaling-1.94.1.tgz",
+      "integrity": "sha512-HC2edeBJ59tgAIUBERY9K1KClByMFPiMbo4nrLunWHiX4VnLwRELy9D1q8WU2nhs/cbJ+RBL/FN4TlSt/R7Sjg==",
+      "requires": {
+        "@aws-cdk/aws-autoscaling-common": "1.94.1",
+        "@aws-cdk/aws-cloudwatch": "1.94.1",
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-elasticloadbalancing": "1.94.1",
+        "@aws-cdk/aws-elasticloadbalancingv2": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-sns": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-autoscaling-common": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.94.1.tgz",
+      "integrity": "sha512-XI6dIR3IobS50SMOlbNj5PlGgL1/FlOrls8RyfSXmPfK0sa3S+C2I6yfAEDYwFsBJkgoJstmHZGG+8m7KeW3dQ==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-autoscaling-hooktargets": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-hooktargets/-/aws-autoscaling-hooktargets-1.94.1.tgz",
+      "integrity": "sha512-Qhui+1yTpIB3JVaub/dmLB3CqaUBD5vv1c46MO76djhiu8VP2c5O0eV9WM+f1BSg7btDtXhB+ZZqk3aU+tUAig==",
+      "requires": {
+        "@aws-cdk/aws-autoscaling": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-kms": "1.94.1",
+        "@aws-cdk/aws-lambda": "1.94.1",
+        "@aws-cdk/aws-sns": "1.94.1",
+        "@aws-cdk/aws-sns-subscriptions": "1.94.1",
+        "@aws-cdk/aws-sqs": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-batch": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-batch/-/aws-batch-1.94.1.tgz",
+      "integrity": "sha512-DYAnEHKYG6FqpIMe9xLzHDkrf+Y/+Y18yGu2qCmMNxWEbcUUm7hE3nbSBD6Oc4nGQWtac6IASMi6duwlr1L8Aw==",
+      "peer": true,
+      "requires": {}
+    },
+    "@aws-cdk/aws-certificatemanager": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.94.1.tgz",
+      "integrity": "sha512-AfEGF8ongl/UizPYs/ETKorzbwTCzxlrGLaO81VZucz5ykEegHNrRVzVrMPhquHDQdH5TeKsKvBhi97ZzE3X8Q==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-lambda": "1.94.1",
+        "@aws-cdk/aws-route53": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-cloudformation": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.94.1.tgz",
+      "integrity": "sha512-+HTjG6ud/NeB+t6sArPzg6nXJNIDszqR8mMyKWiHvZ8ZqhFEZdmUviRzvcrI2IAJp/JgKD3RTZC8DmxqtBIJzw==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-lambda": "1.94.1",
+        "@aws-cdk/aws-s3": "1.94.1",
+        "@aws-cdk/aws-sns": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/cx-api": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-cloudfront": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudfront/-/aws-cloudfront-1.94.1.tgz",
+      "integrity": "sha512-JzLXx+kOZtvK3IvdwPBUPPQPwyK1EluQ2ZjQpOtcZL7sVB8nHWRAQlpSW2drc0b6ijE6YP1fZWrc12b93ohDbA==",
+      "requires": {
+        "@aws-cdk/aws-certificatemanager": "1.94.1",
+        "@aws-cdk/aws-cloudwatch": "1.94.1",
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-kms": "1.94.1",
+        "@aws-cdk/aws-lambda": "1.94.1",
+        "@aws-cdk/aws-s3": "1.94.1",
+        "@aws-cdk/aws-ssm": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-cloudwatch": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.94.1.tgz",
+      "integrity": "sha512-11b7N9xKm2m83BUCh6Cm0yyBIDmEgvwC7r3grNeYsj5vEDjcA56d4RlwGwkV7Grl5FpcuCvr5adtcIqYQa9Gng==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-codebuild": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codebuild/-/aws-codebuild-1.94.1.tgz",
+      "integrity": "sha512-lVTheXuBFZBBPFkShcupqgXq7kziSoWt8D/UCXpGfnxh1+FAi+u868wNXp3Db/EsTzTI5LW9p1yzngq3gKOdFA==",
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.94.1",
+        "@aws-cdk/aws-codecommit": "1.94.1",
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-ecr": "1.94.1",
+        "@aws-cdk/aws-ecr-assets": "1.94.1",
+        "@aws-cdk/aws-events": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-kms": "1.94.1",
+        "@aws-cdk/aws-logs": "1.94.1",
+        "@aws-cdk/aws-s3": "1.94.1",
+        "@aws-cdk/aws-s3-assets": "1.94.1",
+        "@aws-cdk/aws-secretsmanager": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/region-info": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-codecommit": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codecommit/-/aws-codecommit-1.94.1.tgz",
+      "integrity": "sha512-grf+7GMsEtX++sBMG1ttYjCuHFghHLaV4bagZpvBjtAHxOPlO7rMe+WEc4ZU8lykt+tm/EfmmSYp1oKbOpezEQ==",
+      "requires": {
+        "@aws-cdk/aws-events": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-codedeploy": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codedeploy/-/aws-codedeploy-1.94.1.tgz",
+      "integrity": "sha512-55rW+g8vTdqarepbxVLEG9K1g4MKHpFEO3kIo6Z0rFgbS0xk244kNae2m9Bg6qXarcy6Fsj5wCL1cILk9rwvKg==",
+      "peer": true,
+      "requires": {}
+    },
+    "@aws-cdk/aws-codeguruprofiler": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.94.1.tgz",
+      "integrity": "sha512-8QBvoScA85NUlNmG2Bo13lOLWDcLI+DvPkb7qcS+oKHNboWwu5iuVUApCXQg/cE2XyMLRyX/QZdSzVkUDrEpNA==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-codepipeline": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codepipeline/-/aws-codepipeline-1.94.1.tgz",
+      "integrity": "sha512-1QSguGHyjOsUMsuE+c6YA3RvEDim6RP8fHNNafqqBB8A4bBDVLRJ8PSEaxagJGQ4ataOU1LZD2StaccSVvrLrg==",
+      "requires": {
+        "@aws-cdk/aws-events": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-kms": "1.94.1",
+        "@aws-cdk/aws-s3": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-codepipeline-actions": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codepipeline-actions/-/aws-codepipeline-actions-1.94.1.tgz",
+      "integrity": "sha512-GvyrKCoc8yEbyhacE+5Y5Ovk118xh7BeuWKn928DfNMHSmrN1NSuzPyhl51drdXVMR8bjT8wJtHpkXgtd33TeA==",
+      "requires": {
+        "case": "1.6.3"
+      },
+      "dependencies": {
+        "case": {
+          "version": "1.6.3",
+          "bundled": true
+        }
+      }
+    },
+    "@aws-cdk/aws-codestarnotifications": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codestarnotifications/-/aws-codestarnotifications-1.94.1.tgz",
+      "integrity": "sha512-sTgKgs/JOUABdXEnyZ+sNaQ2U5uk8mjZ+CWljQjRRqqUTPMDKoNpyrGxZb4SweO+7LDqrZM/CEA5P6UlqA7ApQ==",
+      "requires": {
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-cognito": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cognito/-/aws-cognito-1.94.1.tgz",
+      "integrity": "sha512-9BxCqIFc0wMCOdf9gzHxr9Xr1u7rVOh2x8kNYR0jli1xkjd89/hCyTqLPFcdfaFquW9bT3BTvR2mX+BGn5LejA==",
+      "requires": {
+        "@aws-cdk/aws-certificatemanager": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-lambda": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/custom-resources": "1.94.1",
+        "constructs": "^3.2.0",
+        "punycode": "^2.1.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "bundled": true
+        }
+      }
+    },
+    "@aws-cdk/aws-ec2": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-1.94.1.tgz",
+      "integrity": "sha512-Jh/W9xmkmmX2wUyKYQikFKLFjHYqSaLPV9s03fpAGOMGwrxgvlHJ5m2fGAKwwygAgxnFdkP1QjSgRy5mgoTL2g==",
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-kms": "1.94.1",
+        "@aws-cdk/aws-logs": "1.94.1",
+        "@aws-cdk/aws-s3": "1.94.1",
+        "@aws-cdk/aws-s3-assets": "1.94.1",
+        "@aws-cdk/aws-ssm": "1.94.1",
+        "@aws-cdk/cloud-assembly-schema": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/cx-api": "1.94.1",
+        "@aws-cdk/region-info": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-ecr": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr/-/aws-ecr-1.94.1.tgz",
+      "integrity": "sha512-jq3CAkzntedLRQMJyCbPo0UtfDJtaToAxxP0l/ChaQifzw8grMYl/GVoLcGTqNMLivWWLF6jO5EBlapi7qEs5w==",
+      "requires": {
+        "@aws-cdk/aws-events": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-ecr-assets": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.94.1.tgz",
+      "integrity": "sha512-QtbHcrs69V9jiIXvPXFQAfhNEzgXGoAtdI7SdkW8OT6UCYpgz0aaPD6bo89Q7cIY46cEq0NoSsNLAZRYxgyk/Q==",
+      "requires": {
+        "@aws-cdk/assets": "1.94.1",
+        "@aws-cdk/aws-ecr": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-s3": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/cx-api": "1.94.1",
+        "constructs": "^3.2.0",
+        "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
+      }
+    },
+    "@aws-cdk/aws-ecs": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecs/-/aws-ecs-1.94.1.tgz",
+      "integrity": "sha512-w1KZ3BVNOrysp9Jjcg2ddf1iEg6hSd8qZ8/GrZsS+qAZXTY0uNWr1ZbcZGNn3xWdtRZNkdbfEjTEuw/V2iUFmg==",
+      "requires": {
+        "@aws-cdk/aws-applicationautoscaling": "1.94.1",
+        "@aws-cdk/aws-autoscaling": "1.94.1",
+        "@aws-cdk/aws-autoscaling-hooktargets": "1.94.1",
+        "@aws-cdk/aws-certificatemanager": "1.94.1",
+        "@aws-cdk/aws-cloudwatch": "1.94.1",
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-ecr": "1.94.1",
+        "@aws-cdk/aws-ecr-assets": "1.94.1",
+        "@aws-cdk/aws-elasticloadbalancing": "1.94.1",
+        "@aws-cdk/aws-elasticloadbalancingv2": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-kms": "1.94.1",
+        "@aws-cdk/aws-lambda": "1.94.1",
+        "@aws-cdk/aws-logs": "1.94.1",
+        "@aws-cdk/aws-route53": "1.94.1",
+        "@aws-cdk/aws-route53-targets": "1.94.1",
+        "@aws-cdk/aws-s3": "1.94.1",
+        "@aws-cdk/aws-s3-assets": "1.94.1",
+        "@aws-cdk/aws-secretsmanager": "1.94.1",
+        "@aws-cdk/aws-servicediscovery": "1.94.1",
+        "@aws-cdk/aws-sns": "1.94.1",
+        "@aws-cdk/aws-sqs": "1.94.1",
+        "@aws-cdk/aws-ssm": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/cx-api": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-efs": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-efs/-/aws-efs-1.94.1.tgz",
+      "integrity": "sha512-rU9LaUe824+RStI+aoV0uJULC0pLtTDyq7INrv2lP/2IvtP2xC5GxkY5UexP4jKa2ONcnytIRi8tJMUf7inM3w==",
+      "requires": {
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-kms": "1.94.1",
+        "@aws-cdk/cloud-assembly-schema": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/cx-api": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-elasticloadbalancing": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-1.94.1.tgz",
+      "integrity": "sha512-J8eNu0GY8lRFg6s5GwPCl2xdVMg/VaqCSnwKjzar8opXDpKPFcmDOzXtEuhsR63vw7k3oG8WBoOUlUkkHkUemg==",
+      "requires": {
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-elasticloadbalancingv2": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-1.94.1.tgz",
+      "integrity": "sha512-0HUk6QIUTTCE3iWapzOFRwih2nW+LSL6oZDzyawP6ekoPw/rCfcR4AdRcU/ByirRTHWG3WRzoBeOb4jltQYenQ==",
+      "requires": {
+        "@aws-cdk/aws-certificatemanager": "1.94.1",
+        "@aws-cdk/aws-cloudwatch": "1.94.1",
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-lambda": "1.94.1",
+        "@aws-cdk/aws-s3": "1.94.1",
+        "@aws-cdk/cloud-assembly-schema": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/cx-api": "1.94.1",
+        "@aws-cdk/region-info": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-events": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-1.94.1.tgz",
+      "integrity": "sha512-5S8PnBM3ApQ+ghW6C+Jpm543zN4lFESA6SViWHCrFXEcmVWnM4QeDl5QbU4Gu68pLqmr3dAbf22Yf9zUfA8aYQ==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-events-targets": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events-targets/-/aws-events-targets-1.94.1.tgz",
+      "integrity": "sha512-hp2+XVnkTHpbGVd/hzIC9Jf048Ct1NQNqFal1MfnvfS8HgHRCBsul0egmMcxQ13Zw9drzit3TJdBuTOZ4GmVJA==",
+      "peer": true,
+      "requires": {}
+    },
+    "@aws-cdk/aws-globalaccelerator": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-globalaccelerator/-/aws-globalaccelerator-1.94.1.tgz",
+      "integrity": "sha512-40uZK7nMb7EAGZVmij9sAi1Ql3M9wuFwfDubYIOCFPunxLF5kDdsbj4T33L08ys8ODOTq+qQwetp7cDxnPmvpg==",
+      "requires": {
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/custom-resources": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-iam": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-1.94.1.tgz",
+      "integrity": "sha512-LzdIZzRntlbidGjTG4FXENoMw2QYJQNU6gC9vERHV59NQceOIzzOPlhu+JtbjHpJaY1JN81yQQ01/q317zsIBQ==",
+      "requires": {
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/region-info": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-kinesis": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kinesis/-/aws-kinesis-1.94.1.tgz",
+      "integrity": "sha512-UO9RUVGExxuHfwnRqAiYgLNbGNe4zoxFXT3C3a3bAqecrTL1PxYunEDDgrby+hwu9YwdvKCw6wszFTzCthMF4A==",
+      "peer": true,
+      "requires": {}
+    },
+    "@aws-cdk/aws-kinesisfirehose": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kinesisfirehose/-/aws-kinesisfirehose-1.94.1.tgz",
+      "integrity": "sha512-IoJ6dxjJixMrnQyee1yiZ05J0TjoHnHvBNdMIawkxKGdl/uUTN8y0lvW1zV+8FqFbjuEi3Tp1FYiCk6KjHkWEA==",
+      "peer": true,
+      "requires": {}
+    },
+    "@aws-cdk/aws-kms": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-1.94.1.tgz",
+      "integrity": "sha512-2XUMUKC/wiEsOEC32SvhNl19BpdJgoVCXbF6BCXFPcz9uEYb4DsDIOpdw/9N2sFSKImgpmNfnlNE0qomIqb9ow==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/cx-api": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-lambda": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-1.94.1.tgz",
+      "integrity": "sha512-hRnjWqVJb4OJfX+OL8elpJjuouB/3ryaXFK+b/UJZzT5P+0aY7g6aDC426NsfZpy8JRz5Xcclh4c8nvkIL43EQ==",
+      "requires": {
+        "@aws-cdk/aws-applicationautoscaling": "1.94.1",
+        "@aws-cdk/aws-cloudwatch": "1.94.1",
+        "@aws-cdk/aws-codeguruprofiler": "1.94.1",
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-ecr": "1.94.1",
+        "@aws-cdk/aws-ecr-assets": "1.94.1",
+        "@aws-cdk/aws-efs": "1.94.1",
+        "@aws-cdk/aws-events": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-kms": "1.94.1",
+        "@aws-cdk/aws-logs": "1.94.1",
+        "@aws-cdk/aws-s3": "1.94.1",
+        "@aws-cdk/aws-s3-assets": "1.94.1",
+        "@aws-cdk/aws-signer": "1.94.1",
+        "@aws-cdk/aws-sqs": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/cx-api": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-logs": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-1.94.1.tgz",
+      "integrity": "sha512-6RC2fJzfVRAoOmZrThiU1wuciJShinM93gjpABBpG7PNhXTXKkgfRmlxLDq0sl3HnxGoL1hZg5EWWcgYgcK4Aw==",
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-kms": "1.94.1",
+        "@aws-cdk/aws-s3-assets": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-route53": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53/-/aws-route53-1.94.1.tgz",
+      "integrity": "sha512-ywX65oc5FPqGCGizkPrDfaM0XF90N/+GGnmcKGWV9GAilBmOwSI7IhiSZYI5Js0jQj8GBBuzP9J6hkPTWhsaYw==",
+      "requires": {
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-logs": "1.94.1",
+        "@aws-cdk/cloud-assembly-schema": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/custom-resources": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-route53-targets": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53-targets/-/aws-route53-targets-1.94.1.tgz",
+      "integrity": "sha512-wkG4OhWitukrVoZ7LEjV3nPYxhBGkvvlzFBPA9HLJibtaoJqvQF0BQZh17sb/vepDJIS54FFwMa/g04On0GJnA==",
+      "requires": {
+        "@aws-cdk/aws-apigateway": "1.94.1",
+        "@aws-cdk/aws-apigatewayv2": "1.94.1",
+        "@aws-cdk/aws-cloudfront": "1.94.1",
+        "@aws-cdk/aws-cognito": "1.94.1",
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-elasticloadbalancing": "1.94.1",
+        "@aws-cdk/aws-elasticloadbalancingv2": "1.94.1",
+        "@aws-cdk/aws-globalaccelerator": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-route53": "1.94.1",
+        "@aws-cdk/aws-s3": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/region-info": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-s3": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-1.94.1.tgz",
+      "integrity": "sha512-9Ggl7Zgp9ZXSri8yB/RUDgK3YxM4oa/8I1STGc9hGaN6lniZhplJab9dsccVGy458HjnKPeP86OeWcbWgH7PWQ==",
+      "requires": {
+        "@aws-cdk/aws-events": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-kms": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/cx-api": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-s3-assets": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.94.1.tgz",
+      "integrity": "sha512-MkhxS5dQzVMIzx0NBRhgfPtYDcOfBicYpXhvWIT1SkMcwqgR6pCfBm42dWLRChQs1Wdhd+zmv9Nfrpi9PcdMGw==",
+      "requires": {
+        "@aws-cdk/assets": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-kms": "1.94.1",
+        "@aws-cdk/aws-s3": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/cx-api": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-sam": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sam/-/aws-sam-1.94.1.tgz",
+      "integrity": "sha512-5TrY/ywbIOJhdWBayclXZU56XfTPXX9fbFD30USKkmpu+jdmMHZO/iuABlUz+ZIWdl9lLsF2HgA0TjfXX1G/Ow==",
+      "requires": {
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-secretsmanager": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-secretsmanager/-/aws-secretsmanager-1.94.1.tgz",
+      "integrity": "sha512-rhuE7+7WEXp7s1Kli/A+Qh7LJXZybUIow3pbxU3TNHWJD1I3PHAQM5SN4Onp2XkejutnGE6m/nhB7/TzuG+xcg==",
+      "requires": {
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-kms": "1.94.1",
+        "@aws-cdk/aws-lambda": "1.94.1",
+        "@aws-cdk/aws-sam": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "@aws-cdk/cx-api": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-servicecatalog": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-servicecatalog/-/aws-servicecatalog-1.94.1.tgz",
+      "integrity": "sha512-PAqbLACMdAZH8c4NzrLMyMKzOlwX6SakZJEfMVv66uEV9pSAKL7W2KCSzHETn+Ojt9fRKsnwCo2Phaxi5jDHPA==",
+      "peer": true,
+      "requires": {}
+    },
+    "@aws-cdk/aws-servicediscovery": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-servicediscovery/-/aws-servicediscovery-1.94.1.tgz",
+      "integrity": "sha512-k82MKxSrFkcEuTY2f90B7LUeiyOdwz7f7W6BFtMmRDUu5zyeZl8QcpSLp+7RXrPXCJtQJrqss8bMuV139wWyrg==",
+      "requires": {
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-elasticloadbalancingv2": "1.94.1",
+        "@aws-cdk/aws-route53": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-signer": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-signer/-/aws-signer-1.94.1.tgz",
+      "integrity": "sha512-oktp02YKDIiTJiBraN6XXuRN5JOx00qvJKK+SPSzXgPE5kTn9kCQOjS3QyasSam+Vx9la8GCx4ir9TEC/6NoEA==",
+      "requires": {
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-sns": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns/-/aws-sns-1.94.1.tgz",
+      "integrity": "sha512-tGbgOS3rwtigdOTZMMiRHiUqIe4Uklji1OcBtcHAdBoblj/LQArrpZPQuoNGaiZiT0vtAqco25990agKCLibFA==",
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.94.1",
+        "@aws-cdk/aws-events": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-kms": "1.94.1",
+        "@aws-cdk/aws-sqs": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-sns-subscriptions": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns-subscriptions/-/aws-sns-subscriptions-1.94.1.tgz",
+      "integrity": "sha512-HksIHzwDhgnlE+6lwj+3WETqoJuz4zhzceggoFlbd9cDgIq/0T7LUm7M3E9Rhf2VbKdMmJnkTiH8gyKt34XD/A==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-lambda": "1.94.1",
+        "@aws-cdk/aws-sns": "1.94.1",
+        "@aws-cdk/aws-sqs": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-sqs": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sqs/-/aws-sqs-1.94.1.tgz",
+      "integrity": "sha512-579LZ7002KfJB3qPsnVBSR+EMV4Jbj11mk1LNepsTnZgdjs1d2dKZve4ZVY1TOW3jW7cqwM/ZccJ5X9bzwoUlA==",
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-kms": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-ssm": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ssm/-/aws-ssm-1.94.1.tgz",
+      "integrity": "sha512-bsZ5nHnRiNwVVKpEEHZYx/BgH+rd+NzRRaM2yd43LvAsuBuT6ZzN4CcnjHMMKtoucNkBI0GRcaHc/MyXRP3bRw==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-kms": "1.94.1",
+        "@aws-cdk/cloud-assembly-schema": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-stepfunctions": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-stepfunctions/-/aws-stepfunctions-1.94.1.tgz",
+      "integrity": "sha512-jLa14T+AD4AmjU7zCRWrWFPIedgDBdxjImkbJBYnMV2s/cmQC/k/cGFD/u2+fMUCe8pZTsRhCps8o5MUXw2/cw==",
+      "peer": true,
+      "requires": {}
+    },
+    "@aws-cdk/cloud-assembly-schema": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.94.1.tgz",
+      "integrity": "sha512-Cp1O8JQBcJl6uqdRSIagqvCrRdnvUu18G7T4daMbIP9zLPimXHlIwEOxg3um/ivV/bCO4JdJwWnyi15MjbqF+Q==",
+      "requires": {
+        "jsonschema": "^1.4.0",
+        "semver": "^7.3.4"
+      },
+      "dependencies": {
+        "jsonschema": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "bundled": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.4",
+          "bundled": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "bundled": true
+        }
+      }
+    },
+    "@aws-cdk/core": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/core/-/core-1.94.1.tgz",
+      "integrity": "sha512-wMbiPFnAEGNd3CInGiS1qr3/8w356g3NleiKCD1NI2RdIdXUD9Dba5DhtuGJYXGLsysrvwRiEqux2LrH/2A2JQ==",
+      "requires": {
+        "@aws-cdk/cloud-assembly-schema": "1.94.1",
+        "@aws-cdk/cx-api": "1.94.1",
+        "@aws-cdk/region-info": "1.94.1",
+        "@balena/dockerignore": "^1.0.2",
+        "constructs": "^3.2.0",
+        "fs-extra": "^9.1.0",
+        "ignore": "^5.1.8",
+        "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "@balena/dockerignore": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "at-least-node": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "fs-extra": {
+          "version": "9.1.0",
+          "bundled": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.6",
+          "bundled": true
+        },
+        "ignore": {
+          "version": "5.1.8",
+          "bundled": true
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "bundled": true
+        }
+      }
+    },
+    "@aws-cdk/custom-resources": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/custom-resources/-/custom-resources-1.94.1.tgz",
+      "integrity": "sha512-ArosnFXRExSoBsIJ4wixrEnfynZ6OIDV9w+C8zjc6E0/fsuYlDgttyDdF2IPPFRXW6TE8o/V+Dr8M4pHKhv6pQ==",
+      "requires": {
+        "@aws-cdk/aws-cloudformation": "1.94.1",
+        "@aws-cdk/aws-ec2": "1.94.1",
+        "@aws-cdk/aws-iam": "1.94.1",
+        "@aws-cdk/aws-lambda": "1.94.1",
+        "@aws-cdk/aws-logs": "1.94.1",
+        "@aws-cdk/aws-sns": "1.94.1",
+        "@aws-cdk/core": "1.94.1",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/cx-api": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.94.1.tgz",
+      "integrity": "sha512-ME6A7dsHbyZv859jhmUhGv9D9soShS0Jafruad87iphBuujfaxruG3aHc8UGIDV6opaW8euVLrEVNZ3H0cMM/w==",
+      "requires": {
+        "@aws-cdk/cloud-assembly-schema": "1.94.1",
+        "semver": "^7.3.4"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "bundled": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.4",
+          "bundled": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "bundled": true
+        }
+      }
+    },
+    "@aws-cdk/region-info": {
+      "version": "1.94.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.94.1.tgz",
+      "integrity": "sha512-FcflZlta6SqlebWT0Dhwo3FLTblbsUSh7T1J5uRG0BINw2EwunaQr/isl23M1qQoaASsnY1TIbMt+WYYsWbuNQ=="
+    },
+    "@types/node": {
+      "version": "12.20.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.6.tgz",
+      "integrity": "sha512-sRVq8d+ApGslmkE9e3i+D3gFGk7aZHAT+G4cIpIEdLJYPsWiSPwcAnJEjddLQQDqV3Ra2jOclX/Sv6YrvGYiWA==",
+      "dev": true
+    },
+    "constructs": {
+      "version": "3.3.71",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.71.tgz",
+      "integrity": "sha512-3KFtTsA7OV27m/+pJhN4iJkKzHbPIPvyvEX5BQ/JCAWjfCHOQEVpIgxHLpT4i8L1OFta+pJrzcEVAHo6UitwqA=="
+    },
+    "typescript": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "dev": true
+    }
+  }
+}

--- a/infra/package.json
+++ b/infra/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "local-container-endpoints-pipeline",
+  "version": "1.0.0",
+  "description": "Pipeline for publishing Docker image for local container endpoints",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w",
+    "cdk": "cdk"
+  },
+  "author": {
+    "name": "Amazon Web Services",
+    "url": "https://aws.amazon.com",
+    "organization": true
+  },
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "@types/node": "^12.15.0",
+    "typescript": "~3.8.3"
+  },
+  "dependencies": {
+    "@aws-cdk/aws-codebuild": "*",
+    "@aws-cdk/aws-codepipeline": "*",
+    "@aws-cdk/aws-codepipeline-actions": "*",
+    "@aws-cdk/aws-ec2": "*",
+    "@aws-cdk/aws-ecr": "*",
+    "@aws-cdk/aws-ecs": "*",
+    "@aws-cdk/aws-iam": "*",
+    "@aws-cdk/core": "*"
+  }
+}

--- a/infra/pipeline.ts
+++ b/infra/pipeline.ts
@@ -101,21 +101,10 @@ class EcsLocalContainerEndpointsImagePipeline extends cdk.Stack {
       }));
 
       verifyProject.addToRolePolicy(new iam.PolicyStatement({
-        actions: ["ecr:GetAuthorizationToken",
-          "ecr:BatchCheckLayerAvailability",
-          "ecr:GetDownloadUrlForLayer",
-          "ecr:GetRepositoryPolicy",
-          "ecr:DescribeRepositories",
-          "ecr:ListImages",
-          "ecr:DescribeImages",
-          "ecr:BatchGetImage",
-          "ecr:InitiateLayerUpload",
-          "ecr:UploadLayerPart",
-          "ecr:CompleteLayerUpload",
-          "ecr:PutImage",
+        actions: [
           "secretsmanager:GetSecretValue",
         ],
-        resources: ["*"]
+        resources: ["com.amazonaws.ec2.madison.dockerhub.amazon-ecs-local-container-endpoints.credentials"]
       }));
 
       const buildAction = new actions.CodeBuildAction({

--- a/infra/pipeline.ts
+++ b/infra/pipeline.ts
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+import codebuild = require('@aws-cdk/aws-codebuild');
+import codepipeline = require('@aws-cdk/aws-codepipeline');
+import actions = require('@aws-cdk/aws-codepipeline-actions');
+import iam = require('@aws-cdk/aws-iam');
+import cdk = require('@aws-cdk/core');
+
+/**
+ * Simple two-stage pipeline to build the base image for the local container endpoints image.
+ * [GitHub source] -> [CodeBuild build, pushes image to DockerHub]
+ *
+ * TODO: use docker manifest and ECR public
+ */
+class EcsLocalContainerEndpointsImagePipeline extends cdk.Stack {
+  constructor(parent: cdk.App, name: string, props?: cdk.StackProps) {
+    super(parent, name, props);
+
+    // Instantiate pipeline
+    const pipeline = new codepipeline.Pipeline(this, 'Pipeline', {
+      pipelineName: 'local-container-endpoints-image',
+    });
+
+    // Source stage
+    // Secret under ecs-local-container-endpoints+release@amazon.com
+    const githubAccessToken = cdk.SecretValue.secretsManager('EcsDevXGitHubToken');
+
+    const sourceOutput = new codepipeline.Artifact('SourceArtifact');
+    const sourceAction = new actions.GitHubSourceAction({
+      actionName: 'GitHubSource',
+      owner: 'awslabs',
+      repo: 'amazon-ecs-local-container-endpoints',
+      oauthToken: githubAccessToken,
+      branch: 'mainline',
+      output: sourceOutput
+    });
+
+    pipeline.addStage({
+      stageName: 'Source',
+      actions: [sourceAction],
+    });
+
+    // Build stage
+    const buildStage = pipeline.addStage({
+      stageName: 'Build',
+    });
+
+    const platforms = [
+      {'arch': 'amd64', 'buildImage': codebuild.LinuxBuildImage.AMAZON_LINUX_2_3},
+      {'arch': 'arm64', 'buildImage': codebuild.LinuxBuildImage.AMAZON_LINUX_2_ARM},
+    ];
+
+    // Create build action for each platform
+    for (const platform of platforms) {
+      const project = new codebuild.PipelineProject(this, `BuildImage-${platform['arch']}`, {
+        buildSpec: codebuild.BuildSpec.fromSourceFilename('./infra/buildspec.yml'),
+        environment: {
+          buildImage: platform['buildImage'],
+          privileged: true
+        }
+      });
+
+      project.addToRolePolicy(new iam.PolicyStatement({
+        actions: ["ecr:GetAuthorizationToken",
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:GetRepositoryPolicy",
+          "ecr:DescribeRepositories",
+          "ecr:ListImages",
+          "ecr:DescribeImages",
+          "ecr:BatchGetImage",
+          "ecr:InitiateLayerUpload",
+          "ecr:UploadLayerPart",
+          "ecr:CompleteLayerUpload",
+          "ecr:PutImage",
+          "secretsmanager:GetSecretValue",
+        ],
+        resources: ["*"]
+      }));
+
+      const buildAction = new actions.CodeBuildAction({
+        actionName: `Build-${platform['arch']}`,
+        project,
+        input: sourceOutput
+      });
+
+      // Add build action for each platform to the build stage
+      buildStage.addAction(buildAction);
+    }
+  }
+}
+
+const app = new cdk.App();
+
+new EcsLocalContainerEndpointsImagePipeline(app, 'EcsLocalContainerEndpointsImagePipeline', {
+  env: { account: process.env['CDK_DEFAULT_ACCOUNT'], region: 'us-west-2' },
+  tags: {
+    project: "amazon-ecs-local-container-endpoints"
+  }
+});
+app.synth();

--- a/infra/tsconfig.json
+++ b/infra/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "target":"ES2018",
+        "module": "commonjs",
+        "lib": ["es2016", "es2017.object", "es2017.string"],
+        "declaration": true,
+        "strict": true,
+        "noImplicitAny": false,
+        "strictNullChecks": true,
+        "noImplicitThis": true,
+        "alwaysStrict": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": false,
+        "inlineSourceMap": true,
+        "inlineSources": true,
+        "experimentalDecorators": true,
+        "strictPropertyInitialization":false
+    },
+    "exclude": ["cdk.out"]
+}

--- a/integ/docker-compose.yml
+++ b/integ/docker-compose.yml
@@ -18,7 +18,7 @@ networks:
 services:
   # The ECS Local container, which vends credentials and metadata
   ecs-local:
-    image: amazon/amazon-ecs-local-container-endpoints:latest
+    image: amazon/amazon-ecs-local-container-endpoints:latest-amd64
     ports:
       - "80:80"
     volumes:

--- a/scripts/build_binary.sh
+++ b/scripts/build_binary.sh
@@ -29,4 +29,4 @@ go run gen/version-gen.go
 
 cd "${ROOT}"
 
-GOOS=$TARGET_GOOS CGO_ENABLED=0 GO111MODULE=on go build -mod=vendor -installsuffix cgo -a -ldflags '-s' -o $1/local-container-endpoints ./
+GOOS=$TARGET_GOOS GOARCH=$GOARCH CGO_ENABLED=0 GO111MODULE=on go build -mod=vendor -installsuffix cgo -a -ldflags '-s' -o $1/local-container-endpoints ./


### PR DESCRIPTION
Previously, the images pushed were only for amd64 architecture. This
adds support for building arm64 images. Their respective images will now
have a suffix indicating their architecture, e.g.
`amazon/amazon-ecs-local-container-endpoints:latest-arm64`

This change also ensures that go1.15 is being used to build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
