### PR TITLE
fix: change resource policy to use ARN

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -19,6 +19,8 @@ aws secretsmanager create-secret --region us-west-2 --name EcsDevXGitHubToken --
 
 ## Deploy
 
+Any changes to `pipeline.ts` will require a re-compilation and re-deploy.
+
 To deploy this pipeline, install the AWS CDK CLI: `npm i -g aws-cdk`
 
 Install and build everything: `npm install && npm run build`
@@ -31,3 +33,5 @@ cdk deploy --app 'node pipeline.js'
 ```
 
 See the pipelines in the CodePipeline console.
+
+**NOTE**: Any changes to `pipeline.ts` will require the stack to be re-build wiht `npm run build` and redeployed with `cdk deploy --app 'node pipeline.js'`

--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -12,7 +12,6 @@
         "@aws-cdk/aws-codebuild": "*",
         "@aws-cdk/aws-codepipeline": "*",
         "@aws-cdk/aws-codepipeline-actions": "*",
-        "@aws-cdk/aws-codestarnotifications": "*",
         "@aws-cdk/aws-ec2": "*",
         "@aws-cdk/aws-ecr": "*",
         "@aws-cdk/aws-ecs": "*",
@@ -401,18 +400,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/@aws-cdk/aws-codestarnotifications": {
-      "version": "1.94.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codestarnotifications/-/aws-codestarnotifications-1.94.1.tgz",
-      "integrity": "sha512-sTgKgs/JOUABdXEnyZ+sNaQ2U5uk8mjZ+CWljQjRRqqUTPMDKoNpyrGxZb4SweO+7LDqrZM/CEA5P6UlqA7ApQ==",
-      "dependencies": {
-        "@aws-cdk/core": "1.94.1",
-        "constructs": "^3.2.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0 <13 || >=13.7.0"
-      }
-    },
     "node_modules/@aws-cdk/aws-cognito": {
       "version": "1.94.1",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cognito/-/aws-cognito-1.94.1.tgz",
@@ -437,6 +424,7 @@
       "version": "2.1.1",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -504,12 +492,14 @@
     "node_modules/@aws-cdk/aws-ecr-assets/node_modules/balanced-match": {
       "version": "1.0.0",
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@aws-cdk/aws-ecr-assets/node_modules/brace-expansion": {
       "version": "1.1.11",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -518,12 +508,14 @@
     "node_modules/@aws-cdk/aws-ecr-assets/node_modules/concat-map": {
       "version": "0.0.1",
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@aws-cdk/aws-ecr-assets/node_modules/minimatch": {
       "version": "3.0.4",
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1064,6 +1056,7 @@
       "version": "1.4.0",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -1072,6 +1065,7 @@
       "version": "6.0.0",
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -1083,6 +1077,7 @@
       "version": "7.3.4",
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -1096,7 +1091,8 @@
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/yallist": {
       "version": "4.0.0",
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/@aws-cdk/core": {
       "version": "1.94.1",
@@ -1257,6 +1253,7 @@
       "version": "6.0.0",
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -1268,6 +1265,7 @@
       "version": "7.3.4",
       "inBundle": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -1281,7 +1279,8 @@
     "node_modules/@aws-cdk/cx-api/node_modules/yallist": {
       "version": "4.0.0",
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/@aws-cdk/region-info": {
       "version": "1.94.1",
@@ -1554,15 +1553,6 @@
         }
       }
     },
-    "@aws-cdk/aws-codestarnotifications": {
-      "version": "1.94.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codestarnotifications/-/aws-codestarnotifications-1.94.1.tgz",
-      "integrity": "sha512-sTgKgs/JOUABdXEnyZ+sNaQ2U5uk8mjZ+CWljQjRRqqUTPMDKoNpyrGxZb4SweO+7LDqrZM/CEA5P6UlqA7ApQ==",
-      "requires": {
-        "@aws-cdk/core": "1.94.1",
-        "constructs": "^3.2.0"
-      }
-    },
     "@aws-cdk/aws-cognito": {
       "version": "1.94.1",
       "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cognito/-/aws-cognito-1.94.1.tgz",
@@ -1579,7 +1569,8 @@
       "dependencies": {
         "punycode": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "peer": true
         }
       }
     },
@@ -1630,11 +1621,13 @@
       "dependencies": {
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "peer": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "peer": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1642,11 +1635,13 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "peer": true
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "peer": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2011,11 +2006,13 @@
       "dependencies": {
         "jsonschema": {
           "version": "1.4.0",
-          "bundled": true
+          "bundled": true,
+          "peer": true
         },
         "lru-cache": {
           "version": "6.0.0",
           "bundled": true,
+          "peer": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -2023,13 +2020,15 @@
         "semver": {
           "version": "7.3.4",
           "bundled": true,
+          "peer": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
         "yallist": {
           "version": "4.0.0",
-          "bundled": true
+          "bundled": true,
+          "peer": true
         }
       }
     },
@@ -2138,6 +2137,7 @@
         "lru-cache": {
           "version": "6.0.0",
           "bundled": true,
+          "peer": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -2145,13 +2145,15 @@
         "semver": {
           "version": "7.3.4",
           "bundled": true,
+          "peer": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
         "yallist": {
           "version": "4.0.0",
-          "bundled": true
+          "bundled": true,
+          "peer": true
         }
       }
     },

--- a/infra/pipeline.ts
+++ b/infra/pipeline.ts
@@ -80,31 +80,21 @@ class EcsLocalContainerEndpointsImagePipeline extends cdk.Stack {
       });
 
       buildProject.addToRolePolicy(new iam.PolicyStatement({
-        actions: ["ecr:GetAuthorizationToken",
-          "ecr:BatchCheckLayerAvailability",
-          "ecr:GetDownloadUrlForLayer",
-          "ecr:GetRepositoryPolicy",
-          "ecr:DescribeRepositories",
-          "ecr:ListImages",
-          "ecr:DescribeImages",
-          "ecr:BatchGetImage",
-          "ecr:InitiateLayerUpload",
-          "ecr:UploadLayerPart",
-          "ecr:CompleteLayerUpload",
-          "ecr:PutImage",
-          "ecr-public:*",
+        actions: [
           "secretsmanager:GetSecretValue",
           "sts:GetServiceBearerToken",
           "sts:AssumeRole",
         ],
-        resources: ["*"]
+        resources: [`arn:aws:secretsmanager:us-west-2:${process.env['CDK_DEFAULT_ACCOUNT']}:secret:com.amazonaws.ec2.madison.dockerhub.amazon-ecs-local-container-endpoints.credentials-XIxFhP`]
       }));
 
       verifyProject.addToRolePolicy(new iam.PolicyStatement({
         actions: [
           "secretsmanager:GetSecretValue",
+          "sts:GetServiceBearerToken",
+          "sts:AssumeRole",
         ],
-        resources: ["com.amazonaws.ec2.madison.dockerhub.amazon-ecs-local-container-endpoints.credentials"]
+        resources: [`arn:aws:secretsmanager:us-west-2:${process.env['CDK_DEFAULT_ACCOUNT']}:secret:com.amazonaws.ec2.madison.dockerhub.amazon-ecs-local-container-endpoints.credentials-XIxFhP`]
       }));
 
       const buildAction = new actions.CodeBuildAction({


### PR DESCRIPTION
Previously, the resource specification was only using the name. However, the resource policy requires the full ARN of the resource being permitted on, including the 6-letter suffix.

Also updated package-lock.json to remove unused package.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
