### PR TITLE
chore: get rid of vendor in script and run unit/functionals test in a linux container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,11 +86,21 @@ publish-dockerhub:
 
 .PHONY: test
 test:
-	go test -timeout=120s -v -cover ./local-container-endpoints/...
+	# NOTE: unit tests need to run in a linux/windows environment with the current `amazon-ecs-agents` dependency.
+	# If your dev env is running linux/windows feel free to just:
+	# go test -timeout=120s -v -cover ./local-container-endpoints/...
+	docker build -t amazon-ecs-local-container-endpoints-test -f test.Dockerfile .
+	docker run amazon-ecs-local-container-endpoints-test \
+		go test -timeout=120s -v -cover ./local-container-endpoints/...
 
 .PHONY: functional-test
 functional-test:
-	go test -timeout=120s -v -tags functional -cover ./local-container-endpoints/handlers/functional_tests/...
+	# NOTE: functional tests need to run in a linux/windows environment with the current `amazon-ecs-agents` dependency.
+	# If your dev env running linux/windows feel free to just:
+	# go test -timeout=120s -v -tags functional -cover ./local-container-endpoints/handlers/functional_tests/...
+	docker build -t amazon-ecs-local-container-endpoints-test -f test.Dockerfile .
+	docker run amazon-ecs-local-container-endpoints-test \
+		go test -timeout=120s -v -tags functional -cover ./local-container-endpoints/handlers/functional_tests/...
 
 .PHONY: integ
 integ: build-local-image

--- a/scripts/build_binary.sh
+++ b/scripts/build_binary.sh
@@ -29,4 +29,4 @@ go run gen/version-gen.go
 
 cd "${ROOT}"
 
-GOOS=$TARGET_GOOS GOARCH=$GOARCH CGO_ENABLED=0 GO111MODULE=on go build -mod=vendor -installsuffix cgo -a -ldflags '-s' -o $1/local-container-endpoints ./
+GOOS=$TARGET_GOOS GOARCH=$GOARCH CGO_ENABLED=0 GO111MODULE=on go build -installsuffix cgo -a -ldflags '-s' -o $1/local-container-endpoints ./

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.17
+
+WORKDIR /go/src/github.com/awslabs/amazon-ecs-local-container-endpoints
+
+COPY go.mod go.sum ./
+ARG GOPROXY=direct
+RUN go mod download  # The first build will take 2~3 minutes but will be cached for future builds.
+
+COPY . .
+
+CMD ["echo", "run some tests please"]


### PR DESCRIPTION
1. There is one more place where vendor is used. This PR gets rid of that.
2. Unit/functional tests are not compiling right now on Mac OS because `amazon-ecs-agent` sets a variable only if the OS is linus/windows. This means that on Mac OS, it will throw `xxx not defined` compilation error. This PR containarizes the tests so that they run in a linux environment.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
